### PR TITLE
captureContent parameter in NewHar() method to capture body content of HTTP requests.

### DIFF
--- a/AutomatedTester.BrowserMob/Client.cs
+++ b/AutomatedTester.BrowserMob/Client.cs
@@ -44,10 +44,15 @@ namespace AutomatedTester.BrowserMob
             var parts = url.Split(':');
             _proxy = parts[1].TrimStart('/') + ":" + _port;
         }
-        
-        public void NewHar(string reference = null)
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="reference"></param>
+        /// <param name="captureContent">Whether to capture body content of requests or not</param>
+        public void NewHar(string reference = null, bool captureContent = false)
         {
-            MakeRequest(String.Format("{0}/{1}/har", _baseUrlProxy, _port), "PUT", reference);
+            MakeRequest(String.Format("{0}/{1}/har" + (captureContent ? "?captureContent=true" : ""), _baseUrlProxy, _port), "PUT", reference);
         }
 
         private static WebResponse MakeRequest(string url, string method, string reference = null)

--- a/AutomatedTester.BrowserMob/Server.cs
+++ b/AutomatedTester.BrowserMob/Server.cs
@@ -12,6 +12,7 @@ namespace AutomatedTester.BrowserMob
         private readonly int _port;
         private readonly String _path = string.Empty;
         private const string Host = "localhost";
+        private string _errorMessage = "";
 
         public Server(string path) : this(path, 8080)
         {}
@@ -43,7 +44,7 @@ namespace AutomatedTester.BrowserMob
                     count++;
                     if (count == 30)
                     {
-                        throw new Exception("Can not connect to BrowserMob Proxy");
+                        throw new Exception($"Can not connect to BrowserMob Proxy - {_errorMessage}");
                     }
                 }
             }
@@ -96,8 +97,9 @@ namespace AutomatedTester.BrowserMob
                 socket.Close();
                 return true;
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                _errorMessage = ex.Message;
                 return false;
             }            
         }


### PR DESCRIPTION
- Added an optional parameter in NewHar() method to capture body content of HTTP requests.
```
/// <summary>
/// 
/// </summary>
/// <param name="reference"></param>
/// <param name="captureContent">Whether to capture body content of requests or not</param>
public void NewHar(string reference = null, bool captureContent = false)
{
    MakeRequest(String.Format("{0}/{1}/har" + (captureContent ? "?captureContent=true" : ""), _baseUrlProxy, _port), "PUT", reference);
}
```
- When starting the server, if it fails it displays a proper detailed error message.
```
throw new Exception($"Can not connect to BrowserMob Proxy - {_errorMessage}");
```